### PR TITLE
fix: correção na verificação do qrcode que não pertence a icods

### DIFF
--- a/src/pages/Scanner/index.tsx
+++ b/src/pages/Scanner/index.tsx
@@ -32,6 +32,10 @@ const Scanner = () =>
   const [ popUp, setPopUp ] = useState<PopUp>();
 
   const handleCloseButton = () => {
+    if(popUp?.press == 'Scanner') {
+      setQrCodeValidate( false );
+      setQrcode( undefined );
+    }
     navigation.navigate(popUp?.press || 'Scanner', {qrcode});
   }
 


### PR DESCRIPTION
## Problema
Ao escanear um qrcode que não pertence a icods, o scanner parava de funcionar ao fechar o popUp

## Solução
Foi feita uma verificação em qual tela o usuário irá na sequência, com isso é ativado o Scanner novamente.