### PR TITLE
fix: ajuste nas múltiplas chamadas para a api

### DIFF
--- a/src/components/History/FilterModal/index.tsx
+++ b/src/components/History/FilterModal/index.tsx
@@ -37,7 +37,11 @@ interface ModalInterface {
   visible: boolean,
   pressedOut: () => void,
   confirmedFilter: (data: FilterData) => Promise<void>,
-  initialDateValue?: undefined
+  initialDateValue?: undefined,
+  setSelectedColor: (color: Colors) => void,
+  selectedColor: Colors,  
+  setSelectedDate: (date: Moment | undefined) => void,
+  selectedDate: Moment | undefined,
 }
 
 interface FilterData {
@@ -94,11 +98,15 @@ export const colorsIconsList = [
 export function FilterModal({
     visible, 
     pressedOut, 
-    confirmedFilter 
+    confirmedFilter,
+    setSelectedColor,
+    selectedColor,
+    setSelectedDate,
+    selectedDate
   }: ModalInterface){
-  const [selectedColor, setSelectedColor] = useState<Colors>('noFilter')
+  // const [selectedColor, setSelectedColor] = useState<Colors>('noFilter')
   const [calendarVisible, setCalendarVisible] = useState(false)
-  const [selectedDate, setSelectedDate] = useState<Moment | undefined>(undefined)
+  // const [selectedDate, setSelectedDate] = useState<Moment | undefined>(undefined)
 
   function handleOpenCalendar(){
     setCalendarVisible(true)

--- a/src/components/History/HeaderHistory/index.tsx
+++ b/src/components/History/HeaderHistory/index.tsx
@@ -15,12 +15,17 @@ import { FavoriteButton } from '../../FavoriteButton';
 import { FilterButton } from '../../FilterButton';
 import { Keyboard, Modal, TouchableWithoutFeedback, View } from 'react-native';
 import { FilterModal } from '../FilterModal';
+import { Moment } from 'moment';
 
 interface HeaderHistoryProps {
   favorite: boolean;
   qrCodeDetails?: boolean;
   setFavorite: () => void;
   setColorAndDate: ({ date, color }: ColorAndDateProps) => void;
+  setSelectedColor: (color: Colors) => void,
+  selectedColor: Colors,
+  setSelectedDate: (date: Moment | undefined) => void,
+  selectedDate: Moment | undefined,
 }
 
 interface ColorAndDateProps {
@@ -32,7 +37,12 @@ export function HeaderHistory({
   setColorAndDate, 
   setFavorite, 
   favorite, 
-  qrCodeDetails }: 
+  qrCodeDetails,
+  setSelectedColor,
+  selectedColor,
+  setSelectedDate,
+  selectedDate
+ }: 
   HeaderHistoryProps){
   const navigation = useNavigation();
   const [modalVisible, setModalVisible] = useState(false)
@@ -82,7 +92,11 @@ export function HeaderHistory({
               >
                 <FilterModal
                   visible={modalVisible}
+                  setSelectedColor={setSelectedColor}
+                  selectedColor={selectedColor}
                   pressedOut={() => setModalVisible(!modalVisible)}
+                  selectedDate={selectedDate}
+                  setSelectedDate={setSelectedDate}
                   confirmedFilter={async ({ date, color }) => {
                     
                     setModalVisible(false)


### PR DESCRIPTION
## Problema
A aplicação na tela de histórico estava fazendo múltiplas chamadas para a api, para buscar os qrcodes

## Solução
Modifiquei a forma de como isso ocorre, agora as chamadas acontecem quando o usuário confirmar o filtro, além disso, foi realizado um ajuste para que o filtro selecionado aparecesse quando aberto o modal dos filtros