### PR TITLE
adjust the formula to generate the name

### DIFF
--- a/src/pages/Processing/index.tsx
+++ b/src/pages/Processing/index.tsx
@@ -10,7 +10,6 @@ import ErrorProcessing from '../../assets/images/Icons/editor/error_processing.s
 
 const Processing = ( { route, _ }: any ) =>
 {
-
   const navigation = useNavigation();
   const { user } = useAuth();
   const { qrcode, video } = route.params;
@@ -29,7 +28,7 @@ const Processing = ( { route, _ }: any ) =>
     setProcessedError( false );
 
     let formData = new FormData();
-    const name = (Math.random().toString(36)+'00000000000000000').slice(2, 5+2)
+    const name = (Math.random().toString(36)+'00000000000000000').slice(2, 8+2);
     formData.append( 'file', {
       uri: video,
       type: 'video/mp4',


### PR DESCRIPTION
* Nome do vídeo passou a ser gerado por 8 caracteres aleatórios, baseado na formula:
`(Math.random().toString(36)+'00000000000000000').slice(2, 8+2)`
Exemplo de saída: 'p543i9ay'